### PR TITLE
Adding the configuration of the DNF package manager

### DIFF
--- a/Configure-DnfPackageManager.bash
+++ b/Configure-DnfPackageManager.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Runs this script as root if it is not root.
+function run_as_root() {
+  if [ "$(whoami)" != "root" ]; then
+    echo "This script is not running as root"
+    echo "Elevating privileges..."
+    if [ "$(command -v sudo)" ]; then
+      sudo bash "$0"
+      exit $?
+    else
+      echo "Sudo is not installed"
+      exit 1
+    fi
+  fi
+}
+
+# Running as root
+run_as_root
+
+# Backing up configuration file
+if ! [ -f "/etc/dnf/dnf.conf.old" ]; then
+  cp "/etc/dnf/dnf.conf" "/etc/dnf/dnf.conf.old"
+fi
+
+{
+  echo "[main]"
+  echo "gpgcheck=1"
+  echo "installonly_limit=3"
+  echo "clean_requirements_on_remove=True"
+  echo "best=False"
+  echo "skip_if_unavailable=True"
+
+  # Keeping cached packages
+  echo "keepcache=True"
+
+  # Using the fastest mirror
+  echo "fastestmirror=True"
+} > "/etc/dnf/dnf.conf"

--- a/Configure-DnfPackageManager.bash
+++ b/Configure-DnfPackageManager.bash
@@ -19,9 +19,7 @@ function run_as_root() {
 run_as_root
 
 # Backing up configuration file
-if ! [ -f "/etc/dnf/dnf.conf.old" ]; then
-  cp "/etc/dnf/dnf.conf" "/etc/dnf/dnf.conf.old"
-fi
+cp "/etc/dnf/dnf.conf" "/etc/dnf/dnf.conf.backup.$(date "+%d-%m-%Y_%H:%M:%S")"
 
 {
   echo "[main]"

--- a/Instalar_Henrique_PC.bash
+++ b/Instalar_Henrique_PC.bash
@@ -12,6 +12,12 @@ function run_as_root() {
   # Instala pacotes dnf
   function instalar_pacotes_dnf() {
 
+    # Configurando gerenciador de pacotes DNF
+    bash ./Configure-DnfPackageManager.bash
+
+    # Atualizando todos os pacotes instalados
+    bash ./Update-All.bash
+
     # Habilitando RPM Fusion
     bash ./Enable-RpmFusion.bash
 
@@ -159,6 +165,9 @@ function run_as_root() {
   # Instalando pacotes flatpak
   instalar_pacotes_flatpak
 
+  # Atualizando todos os pacotes instalados
+  bash ./Update-All.bash
+
   # Instalando o Docker
   bash ./Install-DockerDesktop.bash
 
@@ -173,9 +182,6 @@ function run_as_root() {
 
   # Instalando o Peazip
   bash ./Install-Peazip.bash
-
-  # Atualizando todos os pacotes instalados
-  bash ./Update-All.bash
 
   # Instalando script Update-All.bash
   instalar_script_update_all


### PR DESCRIPTION
Adding the script to configure the DNF package manager, changing the file /etc/dnf/dnf.conf so that:
- Will be used the fastest mirror.
- Downloaded packages will be kept in the cache.