### PR TITLE
Fixing the automation of the installation of Peazip

### DIFF
--- a/Install-Peazip.bash
+++ b/Install-Peazip.bash
@@ -4,4 +4,4 @@
 bash ./Install-Flathub.bash
 
 # Installing PeaZip
-flatpak install flathub io.github.peazip.PeaZip
+flatpak install --assumeyes flathub io.github.peazip.PeaZip


### PR DESCRIPTION
Now Peazip installation script will not prompt for user confirmation.